### PR TITLE
Fix modifier parameter ordering in Composable functions

### DIFF
--- a/feature/home/src/main/java/com/conf/mad/todo/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/conf/mad/todo/home/HomeScreen.kt
@@ -156,7 +156,6 @@ fun HomeScreen(
             }
             items(todos, key = { it.id ?: UNDEFINED_ID }) { todo ->
                 TaskItem(
-                    modifier = Modifier.fillMaxWidth(),
                     title = todo.title,
                     status = todo.status,
                     isFavorite = todo.isFavorite,
@@ -172,7 +171,8 @@ fun HomeScreen(
                             !todo.isFavorite
                         )
                     },
-                    onDeleteDialogShow = { onSelectTaskToDelete(todo) }
+                    onDeleteDialogShow = { onSelectTaskToDelete(todo) },
+                    modifier = Modifier.fillMaxWidth()
                 )
             }
             if (isCompletedTaskVisible) {
@@ -198,7 +198,6 @@ fun HomeScreen(
                 }
                 items(completedTasks) { task ->
                     TaskItem(
-                        modifier = Modifier.fillMaxWidth(),
                         title = task.title,
                         status = task.status,
                         isFavorite = task.isFavorite,
@@ -214,7 +213,8 @@ fun HomeScreen(
                                 !task.isFavorite
                             )
                         },
-                        onDeleteDialogShow = { onSelectTaskToDelete(task) }
+                        onDeleteDialogShow = { onSelectTaskToDelete(task) },
+                        modifier = Modifier.fillMaxWidth()
                     )
                 }
             }

--- a/feature/home/src/main/java/com/conf/mad/todo/home/component/TaskItem.kt
+++ b/feature/home/src/main/java/com/conf/mad/todo/home/component/TaskItem.kt
@@ -47,13 +47,13 @@ import com.conf.mad.todo.ui.noRippleClickable
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun TaskItem(
-    modifier: Modifier = Modifier,
     title: String,
     status: TaskStatus,
     isFavorite: Boolean,
     onCompletedValueChange: () -> Unit,
     onFavoriteValueChange: () -> Unit,
-    onDeleteDialogShow: () -> Unit
+    onDeleteDialogShow: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Row(
         modifier = modifier
@@ -117,13 +117,13 @@ internal fun TaskItem(
 private fun TaskItemPreview() {
     TodoTheme {
         TaskItem(
-            modifier = Modifier.fillMaxWidth(),
             title = "Task Title",
             status = TaskStatus.DONE,
             isFavorite = false,
             onCompletedValueChange = {},
             onFavoriteValueChange = {},
-            onDeleteDialogShow = {}
+            onDeleteDialogShow = {},
+            modifier = Modifier.fillMaxWidth()
         )
     }
 }

--- a/feature/post/src/main/java/com/conf/mad/todo/post/component/TaskTextField.kt
+++ b/feature/post/src/main/java/com/conf/mad/todo/post/component/TaskTextField.kt
@@ -49,13 +49,13 @@ import com.conf.mad.todo.ui.noRippleClickable
 
 @Composable
 internal fun TaskTextField(
-    modifier: Modifier = Modifier,
     value: String,
     onValueChange: (String) -> Unit,
+    placeHolder: String,
+    modifier: Modifier = Modifier,
     singleLine: Boolean = false,
     useClearText: Boolean = false,
-    onPressClearText: () -> Unit = {},
-    placeHolder: String
+    onPressClearText: () -> Unit = {}
 ) {
     BasicTextField(
         value = value,


### PR DESCRIPTION
- Fix modifier parameter ordering in Composable functions

Compose component API Guidelines에 따라, modifier paramter 의 위치를  first optional parameter 의 위치로 순서를 변경하였습니다.

reference)
https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-component-api-guidelines.md#modifier-parameter