### PR TITLE
:arrow_up: 의존성 전체 최신화 + AGP 9 마이그레이션

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,7 @@ android {
         applicationId = "com.conf.mad.todo"
         versionCode = libs.versions.versionCode.get().toInt()
         versionName = libs.versions.appVersion.get()
+        targetSdk = libs.versions.targetSdk.get().toInt()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/build-logic/src/main/kotlin/com/conf/mad/todo/dsl/AndroidGradleDsl.kt
+++ b/build-logic/src/main/kotlin/com/conf/mad/todo/dsl/AndroidGradleDsl.kt
@@ -1,14 +1,14 @@
 package com.conf.mad.todo.dsl
 
-import com.android.build.gradle.LibraryExtension
-import com.android.build.gradle.TestedExtension
-import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.dsl.LibraryExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 
-fun Project.androidApplication(action: BaseAppModuleExtension.() -> Unit) {
+fun Project.androidApplication(action: ApplicationExtension.() -> Unit) {
     extensions.configure(action)
 }
 
@@ -16,34 +16,39 @@ fun Project.androidLibrary(action: LibraryExtension.() -> Unit) {
     extensions.configure(action)
 }
 
-fun Project.android(action: TestedExtension.() -> Unit) {
+// CommonExtension lost its type parameters in AGP 9; use the raw type and configure shared settings here.
+fun Project.android(action: CommonExtension.() -> Unit) {
     extensions.configure(action)
 }
 
 fun Project.setupAndroid() {
     android {
+        // AGP 9 removed the block-method overloads on the raw CommonExtension, so configure
+        // each nested DSL through its property with apply { } instead of the block form.
         namespace?.let {
             this.namespace = it
         }
-        compileSdkVersion(36)
+        // Bumped AndroidX deps (core 1.19.0, lifecycle 2.11.0) require minCompileSdk 37.
+        // This is compile-time only; targetSdk stays 36.
+        compileSdk = 37
 
-        defaultConfig {
+        defaultConfig.apply {
             minSdk = 30
-            targetSdk = 36
+            // targetSdk is only meaningful for app modules and was removed from the common
+            // DefaultConfig in AGP 9; it is set in the application module's build file instead.
         }
 
-        compileOptions {
+        compileOptions.apply {
             sourceCompatibility = JavaVersion.VERSION_17
             targetCompatibility = JavaVersion.VERSION_17
             isCoreLibraryDesugaringEnabled = true
         }
-        dependencies {
-            add("coreLibraryDesugaring", libs.library("android-desugar-libs"))
+        testOptions.unitTests {
+            isIncludeAndroidResources = true
         }
-        testOptions {
-            unitTests {
-                isIncludeAndroidResources = true
-            }
-        }
+    }
+    // The new public CommonExtension has no `dependencies` member, so add desugaring on the Project scope.
+    dependencies {
+        add("coreLibraryDesugaring", libs.library("android-desugar-libs"))
     }
 }

--- a/build-logic/src/main/kotlin/com/conf/mad/todo/primitive/AndroidHiltPlugin.kt
+++ b/build-logic/src/main/kotlin/com/conf/mad/todo/primitive/AndroidHiltPlugin.kt
@@ -19,10 +19,8 @@ class AndroidHiltPlugin : Plugin<Project> {
             }
 
             android {
-                packagingOptions {
-                    resources {
-                        excludes += "META-INF/gradle/incremental.annotation.processors"
-                    }
+                packaging.resources {
+                    excludes += "META-INF/gradle/incremental.annotation.processors"
                 }
             }
             dependencies {

--- a/build-logic/src/main/kotlin/com/conf/mad/todo/primitive/AndroidKotlinPlugin.kt
+++ b/build-logic/src/main/kotlin/com/conf/mad/todo/primitive/AndroidKotlinPlugin.kt
@@ -14,10 +14,8 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 class AndroidKotlinPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            with(pluginManager) {
-                apply("org.jetbrains.kotlin.android")
-            }
-
+            // AGP 9 enables built-in Kotlin by default; the kotlin-android plugin is
+            // incompatible with the new DSL, so it is no longer applied here.
             extensions.getByType<KotlinAndroidProjectExtension>().apply {
                 compilerOptions {
                     jvmTarget.set(JvmTarget.JVM_17)

--- a/build-logic/src/main/kotlin/com/conf/mad/todo/primitive/AndroidRoomPlugin.kt
+++ b/build-logic/src/main/kotlin/com/conf/mad/todo/primitive/AndroidRoomPlugin.kt
@@ -16,21 +16,20 @@ class AndroidRoomPlugin : Plugin<Project> {
                 apply("com.google.devtools.ksp")
             }
             android {
-                defaultConfig {
-                    javaCompileOptions {
-                        annotationProcessorOptions {
-                            arguments += mapOf(
-                                "room.schemaLocation" to "$projectDir/schemas",
-                                "room.incremental" to "true"
-                            )
-                        }
+                defaultConfig.javaCompileOptions {
+                    annotationProcessorOptions {
+                        arguments += mapOf(
+                            "room.schemaLocation" to "$projectDir/schemas",
+                            "room.incremental" to "true"
+                        )
                     }
                 }
-                dependencies {
-                    implementation(libs.library("androidx-room"))
-                    ksp(libs.library("androidx-room-compiler"))
-                    implementation(libs.library("androidx-room-ktx"))
-                }
+            }
+            // The new public CommonExtension has no `dependencies` member, so add on the Project scope.
+            dependencies {
+                implementation(libs.library("androidx-room"))
+                ksp(libs.library("androidx-room-compiler"))
+                implementation(libs.library("androidx-room-ktx"))
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlinx.serialization) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.dagger.hilt) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.junit5) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,52 +1,52 @@
 [versions]
-compileSdk = "36"
+compileSdk = "37"
 minSdk = "30"
 targetSdk = "36"
 appVersion = "1.0.0"
 versionCode = "10000"
 
 # kotlin
-kotlin = "2.3.0"
-kotlinx-serialization-json = "1.9.0"
-kotlinx-coroutines = "1.10.2"
-kotlinx-datetime = "0.7.1"
-kotlinx-collections-immutable = "0.4.0"
+kotlin = "2.4.0"
+kotlinx-serialization-json = "1.11.0"
+kotlinx-coroutines = "1.11.0"
+kotlinx-datetime = "0.8.0"
+kotlinx-collections-immutable = "0.5.0"
 
 # java
 javax-inject = "1"
 java-poet = "1.13.0"
 
 # android
-androidx-activity = "1.8.0"
-androidx-activity-compose = "1.12.2"
-androidx-compose-bom = "2025.12.01"
+androidx-activity = "1.13.0"
+androidx-activity-compose = "1.13.0"
+androidx-compose-bom = "2026.06.00"
 androidx-appcompat = "1.7.1"
 androidx-constraint-layout = "2.2.1"
-androidx-core = "1.17.0"
+androidx-core = "1.19.0"
 android-desugar-jdk = "2.1.5"
 androidx-fragment = "1.8.9"
 androidx-hilt-navigation-compose = "1.3.0"
-androidx-lifecycle = "2.10.0"
-androidx-navigation = "2.9.6"
+androidx-lifecycle = "2.11.0"
+androidx-navigation = "2.9.8"
 androidx-room = "2.8.4"
 androidx-startup = "1.2.0"
 
 # third party
-dagger-hilt = "2.57.2"
-accompanist = "0.32.0"
-material = "1.13.0"
-oss = "17.0.1"
-spotless = "8.1.0"
+dagger-hilt = "2.59.2"
+accompanist = "0.36.0"
+material = "1.14.0"
+oss = "17.5.1"
+spotless = "8.7.0"
 
 # test
 junit = "4.13.2"
 androidx-test-ext-junit = "1.3.0"
 androidx-test-espresso = "3.7.0"
-junit5-plugin = "1.14.0.0"
-junit5-jupiter = "6.0.1"
-junit5-android-test = "1.3.0"
+junit5-plugin = "2.0.1"
+junit5-jupiter = "6.1.0"
+junit5-android-test = "2.0.1"
 truth = "1.4.5"
-robolectric = "4.16"
+robolectric = "4.16.1"
 androidx-uiautomator = "2.3.0-alpha03"
 androidx-test = "1.7.0"
 androidx-test-core = "1.7.0"
@@ -54,9 +54,9 @@ espressoIntents = "3.7.0"
 runner = "1.5.2"
 
 # gradle plugin
-agp = "8.13.2"
-ksp = "2.3.4"
-ossp = "0.10.10"
+agp = "9.2.1"
+ksp = "2.3.9"
+ossp = "0.12.0"
 
 [libraries]
 # kotlin
@@ -130,7 +130,6 @@ robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectr
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "dagger-hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## 요약

전체 의존성을 최신 stable로 올렸습니다. 그 과정에서 Hilt 최신(2.59.2)이 AGP 9.0+를 요구해 **AGP 8.13.2 → 9.2.1 메이저 마이그레이션**까지 함께 진행했습니다.

## 버전 변경

| 항목 | 이전 | 이후 |
|---|---|---|
| Kotlin | 2.3.0 | 2.4.0 |
| AGP | 8.13.2 | 9.2.1 |
| Gradle | 9.2.1 | 9.6.0 |
| KSP | 2.3.4 | 2.3.9 |
| dagger-hilt | 2.57.2 | 2.59.2 |
| compose-bom | 2025.12.01 | 2026.06.00 |
| androidx-lifecycle | 2.10.0 | 2.11.0 |
| kotlinx-coroutines | 1.10.2 | 1.11.0 |
| kotlinx-serialization | 1.9.0 | 1.11.0 |
| material | 1.13.0 | 1.14.0 |
| compileSdk | 36 | 37 |

그 외 activity, core, navigation, junit5, robolectric, spotless, oss 등도 최신 stable로 정렬했습니다.

## AGP 9 마이그레이션

AGP 9는 built-in Kotlin과 new DSL이 기본값이라 `build-logic` convention plugin을 손봤습니다.

- `org.jetbrains.kotlin.android` 플러그인 제거 (built-in Kotlin이 대체)
- internal DSL 타입 → public new-DSL 인터페이스
  - `BaseAppModuleExtension` → `com.android.build.api.dsl.ApplicationExtension`
  - `TestedExtension` → `CommonExtension` (AGP 9에서 타입 파라미터 제거되어 raw 타입 사용)
- `packagingOptions` → `packaging`
- `targetSdk`는 app 모듈에서만 유효해져 application 모듈로 이동

## 호환성 메모

- **compileSdk 36 → 37**: bump한 AndroidX 의존성(core 1.19.0, lifecycle 2.11.0)이 `minCompileSdk 37`을 강제. 컴파일 타임 한정이며 `targetSdk`는 36 유지라 런타임 동작 불변.
- KSP는 Kotlin 2.4.0 전용 빌드가 아직 없어 2.3.9(Kotlin 2.3.20 컴파일러)를 사용하지만, built-in Kotlin이 2.4.0으로 정렬되어 정상 동작 확인.

## 검증

- `./gradlew :app:assembleDebug` → BUILD SUCCESSFUL (Kotlin compile + KSP Hilt/Room + Compose, 전 모듈)
- `./gradlew :app:assembleRelease` → BUILD SUCCESSFUL (R8 full-mode minify + resource shrink)
